### PR TITLE
Bug Fixes with Attack Timing and Sounds

### DIFF
--- a/Big Munchin/Assets/Scripts/MoveData.cs
+++ b/Big Munchin/Assets/Scripts/MoveData.cs
@@ -22,9 +22,9 @@ public class MoveData : MonoBehaviour
         hitboxData = new HitboxProperties[hitboxPropertyCollection.Length];//initialize array to match size
         for(int i = 0;i< hitboxPropertyCollection.Length;i++) { 
             hitboxData[i] = hitboxPropertyCollection[i].GetComponent<HitboxProperties>();
-            if (hitboxPropertyCollection[i].GetComponent<HitboxProperties>().GetTimeDisabled() > maxLifespan)
+            if (hitboxPropertyCollection[i].GetComponent<HitboxProperties>().GetTimeDisabled() + hitboxPropertyCollection[i].GetComponent<HitboxProperties>().GetTimeEnabled() > maxLifespan)
             {
-                maxLifespan = hitboxPropertyCollection[i].GetComponent<HitboxProperties>().GetTimeDisabled();
+                maxLifespan = hitboxPropertyCollection[i].GetComponent<HitboxProperties>().GetTimeDisabled() + hitboxPropertyCollection[i].GetComponent<HitboxProperties>().GetTimeEnabled();
                 //Debug.Log(hitboxData[i].GetTimeDisabled());
             }
         }//and then copy over each HitboxProperties component to the hitboxData array

--- a/Big Munchin/Assets/Scripts/ThirdPersonController.cs
+++ b/Big Munchin/Assets/Scripts/ThirdPersonController.cs
@@ -449,17 +449,29 @@ public class ThirdPersonController : MonoBehaviour
         {
             if (fire1Pressed && stamina >= activeMoveset.FirstLightCost() -fatigueAllowance)//if the player pressed left click
             {
+                if ((int)currentPlayerState != 1)
+                {
+                    audioSources[1].pitch = 1.6f + Random.Range(0.0f, 0.2f);
+                    audioSources[1].Play();
+                }
                 //Debug.Log("Fire1 down! Sending Light Attack Request!");
                 currentPlayerState = PlayerState.Attacking;//set player state to attacking
                 activeMoveset.LightAttackCombo();//send a request to light attack
                 ani.SetBool("Walking", false);
+                audioSources[0].Stop();
             }
             else if (fire2Pressed && stamina >= activeMoveset.FirstHeavyCost() - fatigueAllowance)//if the player pressed right click
             {
+                if ((int)currentPlayerState != 1)
+                {
+                    audioSources[1].pitch = 1.6f + Random.Range(0.0f, 0.2f);
+                    audioSources[1].Play();
+                }
                 //Debug.Log("Fire2 down! Sending Heavy Attack Request!");
                 currentPlayerState = PlayerState.Attacking;//set player state to attacking
                 activeMoveset.HeavyAttackCombo();//send a request to heavy attack
                 ani.SetBool("Walking", false);
+                audioSources[0].Stop();
             }
         }       
     }


### PR DESCRIPTION
Moves now stay out and stop at the appropriate time, rather being disabled prematurely. Sounds now play and stop appropriately for attacks, and attacking stops the walking sound effect